### PR TITLE
Remove unnecessary call to generator when updating cron units

### DIFF
--- a/systemd-crontab-update
+++ b/systemd-crontab-update
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 systemctl daemon-reload
-systemctl restart cron.target
+systemctl try-restart cron.target


### PR DESCRIPTION
systemctl daemon-reload already takes care of deleting old unit files
and executing the generators again.

Also use try-restart cron.target to respect administrator's choice of not starting cron.target
