### PR TITLE
process VISUAL in crontab

### DIFF
--- a/crontab
+++ b/crontab
@@ -6,7 +6,8 @@ import os
 import argparse
 import getpass
 
-EDITOR = os.environ.get('EDITOR', '/usr/bin/vim')
+EDITOR = (os.environ.get('EDITOR') or
+	  os.environ.get('VISUAL','/usr/bin/vim'))
 CRONTAB_DIR = '/var/spool/cron'
 
 args_parser = argparse.ArgumentParser(description='maintain crontab files for individual users')


### PR DESCRIPTION
VISUAL is currently not processed in crontab, but is stated in the help text
I never wrote any python code before, this is copied from
http://selenic.com/pipermail/mercurial-devel/2007-December/003627.html ,
but seems to work .
