### PR TITLE
sort time units

### DIFF
--- a/systemd-crontab-generator
+++ b/systemd-crontab-generator
@@ -134,8 +134,8 @@ def parse_crontab(filename, withuser=True, monotonic=False):
 def parse_time_unit(value, values, mapping=int):
     if value == '*':
         return ['*']
-    return list(reduce(lambda a, i: a.union(set(i)), map(values.__getitem__,
-        map(parse_period(mapping), value.split(','))), set()))
+    return sorted(list(reduce(lambda a, i: a.union(set(i)), map(values.__getitem__,
+        map(parse_period(mapping), value.split(','))), set())))
 
 def month_map(month):
     try:


### PR DESCRIPTION
this patch sort the generated OnCalendar and makes it more readable.

Example:

> Description=[Cron] "*/5 \* \* \* \* munin if [ -x /usr/bin/munin-cron ]; then /usr/bin/munin-cron; fi"                            

Before

> OnCalendar=_-_-\* *:0,35,5,40,10,45,15,50,20,55,25,30:00 

After

> OnCalendar=_-_-\* *:0,5,10,15,20,25,30,35,40,45,50,55:00       
