### PR TITLE
Issue #30: error if spool non writable

### DIFF
--- a/src/bin/crontab.rs
+++ b/src/bin/crontab.rs
@@ -164,7 +164,13 @@ fn edit(cron_file: &Path, cron_user: &User, _args: &Args) -> i32 {
         Some(editor) => editor
     };
 
-    let mut tmpfile = NamedTempFile::new_in(USERS_CRONTAB_DIR).unwrap();
+    let mut tmpfile = match NamedTempFile::new_in(USERS_CRONTAB_DIR) {
+        Ok(tmpfile) => tmpfile,
+        Err(err) => {
+            writeln!(stderr, "unable to create a temporary file in {}: {}", USERS_CRONTAB_DIR, err).unwrap();
+            return 1;
+        },
+    };
 
     if let Err(e) = File::open(cron_file).map(|mut file| copy(&mut file, &mut tmpfile)) {
         match e.kind() {
@@ -204,7 +210,13 @@ fn edit(cron_file: &Path, cron_user: &User, _args: &Args) -> i32 {
 
 fn replace(cron_file: &Path, cron_user: &User, args: &Args) -> i32 {
     let mut stderr = stderr();
-    let mut tmpfile = NamedTempFile::new_in(USERS_CRONTAB_DIR).unwrap();
+    let mut tmpfile = match NamedTempFile::new_in(USERS_CRONTAB_DIR) {
+        Ok(tmpfile) => tmpfile,
+        Err(err) => {
+            writeln!(stderr, "unable to create a temporary file in {}: {}", USERS_CRONTAB_DIR, err).unwrap();
+            return 1;
+        },
+    };
 
     match args.arg_file {
         Some(ref name) if &**name == "-" => { let _ = copy(&mut stdin(), &mut tmpfile); },


### PR DESCRIPTION
This is a first patch, the code is duplicated, but my rust-foo is not good enough to understand if there is a better solution for a little piece of code like this.

In the branch [issue-30-proactive-test-experiment](https://github.com/naufraghi/systemd-cron-next/tree/issue-30-proactive-test-experiment) I tried to do a proactive test. But `readonly` checks for `mode == 0o222`, so that's not enough. Nonetheless if you think a check like that is better than 2 late error messages, I can modify the pull request accordingly. I think the best check one can do is to try the tempfile creation and not to guess from file / folder bits.

Curiosity: I’ve noticed that `crontab` in Ubuntu 14.04 creates the temp file in `/tmp/`, I think your solution is OK (atomic move, early permission check), but do you know why `crontab` did that choice?