### PR TITLE
fix warning: unused import: `BufRead`

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,4 +1,4 @@
-use std::io::{self, BufRead, Write};
+use std::io::{self, Write};
 use std::fs::{File, create_dir_all, metadata, set_permissions};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};


### PR DESCRIPTION
```
warning: unused import: `BufRead`, #[warn(unused_imports)] on by default
 --> src/generate.rs:1:21
  |
1 | use std::io::{self, BufRead, Write};
  |                     ^^^^^^^
```