### PR TITLE
depend on rustc-serialize 0.3.20 to fix build failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "1.0.2"
 
 [build-dependencies]
 handlebars = "0.12.0"
-rustc-serialize = "0.3.16"
+rustc-serialize = "0.3.20"
 
 [dependencies]
 cronparse = "0.5.0"
@@ -22,7 +22,7 @@ libc = "0.2.2"
 log = "0.3.4"
 md5 = "0.1.1"
 pgs-files = "0.0.6"
-rustc-serialize = "0.3.16"
+rustc-serialize = "0.3.20"
 tempfile = "1.1.3"
 time = "0.1.34"
 users = "0.5.1"


### PR DESCRIPTION
Newer versions of rust halt compilation with:

  error[E0642]: patterns aren't allowed in methods without bodies

  rustc-serialize-0.3.19/src/serialize.rs:147:45
      |
  147 |                                             &f_name: &str,
      |                                             ^^^^^^^

Issue: https://github.com/systemd-cron/systemd-cron-next/issues/46