### PR TITLE
replace deprecated trim_right_matches with trim_end_matches

### DIFF
--- a/src/bin/mail-on-failure.rs
+++ b/src/bin/mail-on-failure.rs
@@ -21,7 +21,7 @@ fn get_systemd_unit_property(unit: &str, prop: &str) -> Result<String> {
         .output()
         .map(|out| {
             String::from_utf8_lossy(&out.stdout[prop.len() + 1..])
-                .trim_right_matches('\n')
+                .trim_end_matches('\n')
                 .to_owned()
         })
 }
@@ -60,7 +60,7 @@ fn main() {
                 .arg("-n")
                 .output())
             .stdout[..])
-        .trim_right_matches('\n')
+        .trim_end_matches('\n')
         .to_owned();
 
     if hostname.len() == 0 {


### PR DESCRIPTION
trim_end_matches introduced in Rust 1.30.0, deprecation warnings
emitted since 1.33.0.

https://doc.rust-lang.org/std/primitive.str.html#method.trim_end_matches