### PR TITLE
Fixed 30 depreciated warnings(28 'try!' macro, 2 '...')

### DIFF
--- a/src/bin/crontab.rs
+++ b/src/bin/crontab.rs
@@ -305,7 +305,7 @@ fn main() {
 }
 
 fn check_crontab_syntax<P: AsRef<Path>>(path: P) -> Result<(), CrontabFileError> {
-    match try!(CrontabFile::<UserCrontabEntry>::new(path)).find(Result::is_err) {
+    match (CrontabFile::<UserCrontabEntry>::new(path)?).find(Result::is_err) {
         Some(Err(err)) => Err(err),
         _ => Ok(()),
     }


### PR DESCRIPTION
From total 31 depreciated warnings, 30 are fixed. Replaced 28 'try!' macro with '?' and replaced 2 '...' with '..='.